### PR TITLE
Add testGetWeekdays_returns to test if the "defensive copy" solution is working as expected

### DIFF
--- a/src/test/java/dev/mabel/test_java/WeekDayHandlerTest.java
+++ b/src/test/java/dev/mabel/test_java/WeekDayHandlerTest.java
@@ -107,4 +107,12 @@ public class WeekDayHandlerTest {
         assertTrue(weekDayHandler.getWeekdays().isEmpty());
     }
 
+    @Test
+    void testGetWeekdays_returnsCopy() {
+        weekDayHandler.createWeekdaysList();
+        List<String> weekdays = weekDayHandler.getWeekdays();
+        weekdays.clear();
+        assertEquals(7, weekDayHandler.getListLength());
+    }
+
 }


### PR DESCRIPTION
To prevent potentially devastating bugs and ensure a proper encapsulation, the code was implemented using a solution called "_defensive copy_", where the getWeekdays method should return a copy of the weekdays list, not areference to the original list. 

This way, external code can modify the copy without affecting the internal state of the WeekDayHandler object.

- This test specifically checks that getWeekdays() is returning a copy.  